### PR TITLE
Fix undefined conflict method in auth repository

### DIFF
--- a/nwaslouk/lib/core/error/failure.dart
+++ b/nwaslouk/lib/core/error/failure.dart
@@ -17,4 +17,5 @@ class Failure {
   static Failure notFound([String message = 'Not found']) => Failure(message: message, code: 'not_found', statusCode: 404);
   static Failure server([String message = 'Server error']) => Failure(message: message, code: 'server');
   static Failure validation([String message = 'Validation error']) => Failure(message: message, code: 'validation');
+  static Failure conflict([String message = 'Conflict']) => Failure(message: message, code: 'conflict', statusCode: 409);
 }


### PR DESCRIPTION
Add `conflict` static factory to `Failure` class to resolve "The method 'conflict' isn't defined for the type 'Failure'" error.

---
<a href="https://cursor.com/background-agent?bcId=bc-17bfea4a-9c7b-4304-82b4-49138589d27d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-17bfea4a-9c7b-4304-82b4-49138589d27d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

